### PR TITLE
Fix whitespace being squashed when folding

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -24,5 +24,8 @@
   "indentationRules": {
     "increaseIndentPattern": "^(.*\\bclass|.*\\b(for|while|with)\\b(?!.*?do)|.*\\b(if|elseif|when)\\b(?!.*?then)|.*\\belse\\s*$|.*switch|.*[-=]>\\s*$|.*[\\{\\[]$)",
     "decreaseIndentPattern": "^\\s*(\\}|\\]|(else|elseif)\\b)"
-}
+  },
+  "folding": {
+    "offSide": true
+  }
 }


### PR DESCRIPTION
A tiny patch that I tested locally to improve code folding Would close #7 